### PR TITLE
Using environmental timezone

### DIFF
--- a/helpers/cosmetic_helper.rb
+++ b/helpers/cosmetic_helper.rb
@@ -5,7 +5,7 @@ module Sinatra
     end
 
     def local_timestamp(time_str)
-      Time.parse(time_str).getlocal.strftime('%FT%H:%M:%S')
+      Time.parse(time_str + " UTC").getlocal.strftime('%FT%H:%M:%S')
     rescue
       nil
     end

--- a/spectrometer.rb
+++ b/spectrometer.rb
@@ -7,7 +7,6 @@ require_relative 'lib/redshift_metric'
 require_relative 'helpers/cosmetic_helper'
 require_relative 'models/redshift'
 
-ENV['TZ'] = 'Asia/Tokyo'
 # Spectator Controller
 class Spectrometer < Sinatra::Base
   configure :development do


### PR DESCRIPTION
Issue #46

- Redshift would return UTC time
- Application's timezone is set by `/etc/localtime` or ENV['TZ']