### PR TITLE
add context column to STL Error list

### DIFF
--- a/models/sql/errors.sql
+++ b/models/sql/errors.sql
@@ -4,6 +4,7 @@ SELECT
   process,
   recordtime,
   errcode,
+  TRIM(context) AS context,
   TRIM(error) AS error_message
 FROM
   pg_catalog.stl_error AS se

--- a/views/admin/errors.slim
+++ b/views/admin/errors.slim
@@ -8,6 +8,7 @@ div class='column'
         th process
         th recordtime
         th errcode
+        th context
         th error_message
     tbody
       - @errors.each do |error|
@@ -17,4 +18,5 @@ div class='column'
           td = error['process']
           td = local_timestamp(error['recordtime'])
           td = error['errcode']
+          td = error['context']
           td = error['error_message']


### PR DESCRIPTION
Add `context` column to STL Error list.
Because some errors, such as `Divide by zero`, have information in `context` column, but `error` column may be empty